### PR TITLE
fix: Remove unused variable zone

### DIFF
--- a/examples/backupdr_complete_example/terraform.tfvars
+++ b/examples/backupdr_complete_example/terraform.tfvars
@@ -1,7 +1,6 @@
 # common vars
 project_id = "gcp-project-id"
 region  = "us-central1"
-zone    = "us-central1-a"
 
 ## network vars
 network     = "custom-network"

--- a/examples/backupdr_single_project_example/terraform.tfvars
+++ b/examples/backupdr_single_project_example/terraform.tfvars
@@ -1,7 +1,6 @@
 # common vars
-#project_id = "gcp-project-id"
+project_id = "gcp-project-id"
 region = "us-central1"
-zone   = "us-central1-a"
 
 ## network vars
 network     = "custom-network"


### PR DESCRIPTION
Terraform is showing a warning, since tfvars examples contain a variable that is not used.