### PR TITLE
fix: Corrected data types in variables.tf

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -36,8 +36,8 @@ variable "firewall_source_ip_ranges" {
 }
 
 variable "ba_registration" {
-  type        = string
-  default     = "true"
+  type        = bool
+  default     = true
   description = "Flag to register the backup/recovery appliance with the management console. We recommend changing it to false, once the appliance is successfully registered."
 }
 


### PR DESCRIPTION
ba_registration, should be a bool type according to the logic in main.tf file.
Because of this the actifio.reading lasts 1 hr.

I was using cloud build, and my build lasted 1 hr
No error..BUT NO APPLIANCE WAS CREATED
![image](https://github.com/GoogleCloudPlatform/terraform-google-backup-dr/assets/84093797/0da01db3-4e0e-487f-bc59-28861bff2568)

after the reading successful , the appliance should be created which was not in this case