### PR TITLE
fix: Update variables.tf

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -36,8 +36,8 @@ variable "firewall_source_ip_ranges" {
 }
 
 variable "ba_registration" {
-  type        = string
-  default     = "true"
+  type        = bool
+  default     = true
   description = "Flag to register the backup/recovery appliance with the management console. We recommend changing it to false, once the appliance is successfully registered."
 }
 
@@ -68,7 +68,7 @@ variable "management_server_endpoint" {
 
 variable "boot_image" {
   type        = string
-  default     = "projects/backupdr-images/global/images/sky-11-0-10-417"
+  default     = "projects/backupdr-images/global/images/sky-11-0-10-425"
   description = "Provide the boot image for backup/recovery appliance.  Don’t modify this variable to update or upgrade the appliance version. You can upgrade the appliance only through the Backup and DR Service management console."
 }
 


### PR DESCRIPTION
### Corrected the data type
ba_registration, should be a bool type according to the logic in main.tf file.
Because of this the actifio.reading lasts 1 hr.

I was using cloud build, and my build lasted 1 hr
No error..BUT NO APPLIANCE WAS CREATED
![image](https://github.com/GoogleCloudPlatform/terraform-google-backup-dr/assets/84093797/7b915c4d-4167-432b-812e-72a85badacfb)
after the reading successful , the appliance should be created which was not in this case


### Updated Boot Image
425 is latest one
